### PR TITLE
Correct the autoselect database feature if the database default name is changed

### DIFF
--- a/config.php
+++ b/config.php
@@ -39,6 +39,7 @@ define("SQL_XBMC_SOCK", "");
 //define("SQL_XBMC_SOCK", "/run/mysqld/mysqld10.sock");
 define("SQL_XBMC_USER", "root");
 define("SQL_XBMC_PASS", "");
+define("SQL_XBMC_DBNAMEPREFIX", "MyVideos"); // For example : "xbmc_video" or "MyVideos"
 //define("SQL_XBMC_DBNAME", "xbmc_video107");
 define("SQL_XBMC_DBNAME", false); // set to false to autoselect latest XBMC/KODI database
 

--- a/db.php
+++ b/db.php
@@ -2,17 +2,17 @@
 if(!defined("IS_INCLUDED"))	header("Location: index.php");
 
 if(!isset($_SESSION["database"])){
-	// Define dynamically the current xbmc_video database's name
+	// Define dynamically the current SQL_XBMC_DBNAMEPREFIX database's name
 	if(SQL_XBMC_DBNAME === false){
 		try {
 			if(SQL_XBMC_SOCK == "")
 				$db = new PDO("mysql:host=" . SQL_XBMC_HOST . ";dbname=information_schema;port:" . SQL_XBMC_PORT, SQL_XBMC_USER, SQL_XBMC_PASS);
 			else
 				$db = new PDO("mysql:unix_socket=" . SQL_XBMC_SOCK . ";dbname=information_schema", SQL_XBMC_USER, SQL_XBMC_PASS);
-			$stmt = $db->query("SELECT SCHEMA_NAME FROM information_schema.SCHEMATA WHERE SCHEMA_NAME LIKE 'xbmc_video%' ORDER BY SUBSTR(SCHEMA_NAME,11,5)+0 DESC LIMIT 0,1;");
+			$stmt = $db->query("SELECT SCHEMA_NAME FROM information_schema.SCHEMATA WHERE SCHEMA_NAME LIKE '".SQL_XBMC_DBNAMEPREFIX."%' ORDER BY SUBSTR(SCHEMA_NAME,11,5)+0 DESC LIMIT 0,1;");
 			$database = $stmt->fetch();
 			if(empty(trim($database["SCHEMA_NAME"]))){
-				echo "Error, no xbmc_video% database found...";
+				echo "Error, no ".SQL_XBMC_DBNAMEPREFIX."% database found...";
 				exit;
 			} else {
 				$_SESSION["database"] = trim($database["SCHEMA_NAME"]);
@@ -26,7 +26,7 @@ if(!isset($_SESSION["database"])){
 	}
 }
 
-// Connect to xbmc_video% database
+// Connect to SQL_XBMC_DBNAMEPREFIX% database
 $db = null;
 try {
 	if(SQL_XBMC_SOCK == "")

--- a/db.php
+++ b/db.php
@@ -9,7 +9,7 @@ if(!isset($_SESSION["database"])){
 				$db = new PDO("mysql:host=" . SQL_XBMC_HOST . ";dbname=information_schema;port:" . SQL_XBMC_PORT, SQL_XBMC_USER, SQL_XBMC_PASS);
 			else
 				$db = new PDO("mysql:unix_socket=" . SQL_XBMC_SOCK . ";dbname=information_schema", SQL_XBMC_USER, SQL_XBMC_PASS);
-			$stmt = $db->query("SELECT SCHEMA_NAME FROM information_schema.SCHEMATA WHERE SCHEMA_NAME LIKE '".SQL_XBMC_DBNAMEPREFIX."%' ORDER BY SUBSTR(SCHEMA_NAME,11,5)+0 DESC LIMIT 0,1;");
+			$stmt = $db->query("SELECT SCHEMA_NAME FROM information_schema.SCHEMATA WHERE SCHEMA_NAME LIKE '".SQL_XBMC_DBNAMEPREFIX."%' ORDER BY REPLACE(SCHEMA_NAME,'".SQL_XBMC_DBNAMEPREFIX."','')+0 DESC LIMIT 0,1;");
 			$database = $stmt->fetch();
 			if(empty(trim($database["SCHEMA_NAME"]))){
 				echo "Error, no ".SQL_XBMC_DBNAMEPREFIX."% database found...";

--- a/i18n/lang_de.php
+++ b/i18n/lang_de.php
@@ -40,4 +40,7 @@ define("AUTHENTICATION_PASSWD_PLACEHOLDER", "Passwort");
 define("AUTHENTICATION_BUTTON", "Anmelden");
 define("AUTHENTICATION_ERROR_CREDENTIAL", "Falscher Benutzer oder Falsches Passwort...");
 define("AUTHENTICATION_SUCCESS_REDIRECT", "Authentifizierung erfolgreich, Umleiten...");
+
+define("YES", "Ja");
+define("NO", "Nein");
 ?>

--- a/i18n/lang_en.php
+++ b/i18n/lang_en.php
@@ -40,4 +40,7 @@ define("AUTHENTICATION_PASSWD_PLACEHOLDER", "Password");
 define("AUTHENTICATION_BUTTON", "Login");
 define("AUTHENTICATION_ERROR_CREDENTIAL", "Wrong username or password...");
 define("AUTHENTICATION_SUCCESS_REDIRECT", "Authentication success, redirecting...");
+
+define("YES", "Yes");
+define("NO", "No");
 ?>

--- a/i18n/lang_es.php
+++ b/i18n/lang_es.php
@@ -40,4 +40,7 @@ define("AUTHENTICATION_PASSWD_PLACEHOLDER", "Contraseña");
 define("AUTHENTICATION_BUTTON", "Iniciar la sesión");
 define("AUTHENTICATION_ERROR_CREDENTIAL", "Error de autenticación...");
 define("AUTHENTICATION_SUCCESS_REDIRECT", "Autenticación exitosa, redirección permanente...");
+
+define("YES", "Si");
+define("NO", "No");
 ?>

--- a/i18n/lang_fr.php
+++ b/i18n/lang_fr.php
@@ -40,4 +40,7 @@ define("AUTHENTICATION_PASSWD_PLACEHOLDER", "Mot de passe");
 define("AUTHENTICATION_BUTTON", "Connexion");
 define("AUTHENTICATION_ERROR_CREDENTIAL", "Erreur d'authentification...");
 define("AUTHENTICATION_SUCCESS_REDIRECT", "Authentification réussie, redirection en cours...");
+
+define("YES", "Oui");
+define("NO", "Non");
 ?>

--- a/index.php
+++ b/index.php
@@ -36,6 +36,7 @@ $filters = array();
 if(!empty($title)){
 	$filters[] = "(c00 LIKE '%" . $title . "%' OR c16 LIKE '%" . $title . "%' OR c01 LIKE '%" . $title . "%')";
 }
+if(WATCHED_STATUS_FOR_ALL || (ENABLE_AUTHENTICATION && in_array($_SESSION['user'], $WATCH_STATUS_FOR_USERS)))
 if($watched!="*"){
 	if ($watched=="YES")
 	$filters[] = "playCount>=1";

--- a/index.php
+++ b/index.php
@@ -37,10 +37,10 @@ if(!empty($title)){
 	$filters[] = "(c00 LIKE '%" . $title . "%' OR c16 LIKE '%" . $title . "%' OR c01 LIKE '%" . $title . "%')";
 }
 if(WATCHED_STATUS_FOR_ALL || (ENABLE_AUTHENTICATION && in_array($_SESSION['user'], $WATCH_STATUS_FOR_USERS)))
-if($watched!="*"){
+{
 	if ($watched=="YES")
 	$filters[] = "playCount>=1";
-	else
+	if ($watched=="NO")
 	$filters[] = "(playCount <= 0 OR playCount IS NULL)";
 }
 if(!empty($genre)){

--- a/index.php
+++ b/index.php
@@ -24,6 +24,7 @@ if(ENABLE_AUTHENTICATION){
 
 // Clean GET vars for filter
 $title 			= (isset($_GET["title"]) && !empty($_GET["title"])) ? substr($db->quote(trim(strval($_GET["title"]))),1,-1) : "";
+$watched 		= (isset($_GET["watched"]) && !empty($_GET["watched"])) ? substr($db->quote(trim(strval($_GET["watched"]))),1,-1) : "";
 $genre 			= (isset($_GET["genre"]) && !empty($_GET["genre"])) ? substr($db->quote(trim(strval($_GET["genre"]))),1,-1) : "";
 $year 			= (isset($_GET["year"]) && !empty($_GET["year"])) ? intval($_GET["year"]) : "";
 $realisator 	= (isset($_GET["realisator"]) && !empty($_GET["realisator"])) ? substr($db->quote(trim(strval($_GET["realisator"]))),1,-1) : "";
@@ -34,6 +35,12 @@ $offset 		= (isset($_GET["offset"]) && trim(strval($_GET["offset"])) != "" && in
 $filters = array();
 if(!empty($title)){
 	$filters[] = "(c00 LIKE '%" . $title . "%' OR c16 LIKE '%" . $title . "%' OR c01 LIKE '%" . $title . "%')";
+}
+if($watched!="*"){
+	if ($watched=="YES")
+	$filters[] = "playCount>=1";
+	else
+	$filters[] = "(playCount <= 0 OR playCount IS NULL)";
 }
 if(!empty($genre)){
 	$filters[] = "c14 LIKE '%" . $genre . "%'";
@@ -79,7 +86,6 @@ if(count($filters) > 0){
 				" . NAX_MOVIE_VIEW . ".premiered AS movieYear
 			FROM " . NAX_MOVIE_VIEW . " ORDER BY dateAdded DESC LIMIT $offset," . DEFAULT_ENTRIES_DISPLAY . ";"; 
 }
-
 if(isset($_GET["action"]) && $_GET["action"] == "logout"){
 	session_destroy();
 	setcookie("KODIWEBPORTAL", "", time()-3600);
@@ -141,6 +147,14 @@ if(isset($_GET["offset"])){
 ?>
 	<label for="title"><?php echo TITLE_LABEL; ?></label>
 	<input id="title" type="text" name="title" placeholder="Indiana Jones" value="<?php echo htmlentities(stripcslashes($title)); ?>" />
+
+        <label for="watched"><?php echo STATUS_WATCHED_LABEL; ?></label>
+        <select id="watched" name="watched">
+                <option value="*" <?php if ($watched == "*") echo "selected"; ?>>*</option>
+                <option value="YES" <?php if ($watched == "YES") echo "selected"; ?>><?php echo YES;?></option>
+                <option value="NO" <?php if ($watched == "NO") echo "selected"; ?>><?php echo NO;?></option>
+        </select>
+
 
 	<label for="genre"><?php echo GENRE_LABEL; ?></label>
 	<select id="genre" name="genre">

--- a/index.php
+++ b/index.php
@@ -149,13 +149,14 @@ if(isset($_GET["offset"])){
 	<label for="title"><?php echo TITLE_LABEL; ?></label>
 	<input id="title" type="text" name="title" placeholder="Indiana Jones" value="<?php echo htmlentities(stripcslashes($title)); ?>" />
 
-        <label for="watched"><?php echo STATUS_WATCHED_LABEL; ?></label>
-        <select id="watched" name="watched">
-                <option value="*" <?php if ($watched == "*") echo "selected"; ?>>*</option>
-                <option value="YES" <?php if ($watched == "YES") echo "selected"; ?>><?php echo YES;?></option>
-                <option value="NO" <?php if ($watched == "NO") echo "selected"; ?>><?php echo NO;?></option>
-        </select>
-
+<?php if(WATCHED_STATUS_FOR_ALL || (ENABLE_AUTHENTICATION && in_array($_SESSION['user'], $WATCH_STATUS_FOR_USERS))) {
+        echo '<label for="watched">'.STATUS_WATCHED_LABEL.'</label>';
+        echo '<select id="watched" name="watched">';
+        echo '        <option value="*" '; if ($watched == "*") echo 'selected'; echo '>*</option>';
+        echo '        <option value="YES" '; if ($watched == "YES") echo 'selected'; echo '>'.YES.'</option>';
+        echo '        <option value="NO" '; if ($watched == "NO") echo 'selected'; echo '>'.NO.'</option>';
+        echo '</select>';
+}?>
 
 	<label for="genre"><?php echo GENRE_LABEL; ?></label>
 	<select id="genre" name="genre">


### PR DESCRIPTION
If the **name** tag is used for the **videodatabase** entry in Kodi's advancedsettings.xml file, the autoselect database feature doesn't work. This modification fix the issue.